### PR TITLE
Fix workflow permissions for pushing tags

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     # Only run if commit message starts with "Prepare release"
     if: startsWith(github.event.head_commit.message, 'Prepare release')


### PR DESCRIPTION
## 🖖 Mission Briefing (Description)

**What does this PR do?**
Fixes the `publish-release.yml` workflow by adding explicit write permissions for pushing git tags.

**Why is this change needed?**
The workflow was failing with a 403 Permission Denied error when attempting to push tags. GitHub's default `GITHUB_TOKEN` has read-only permissions and requires explicit `contents: write` permission to push tags to the repository.

**Additional context:**
- Error occurred at: https://github.com/jasonleibowitz/faker-galactic/actions/runs/19874377444/job/56957975646
- Root cause: Missing `permissions` block in workflow
- Fix: Added `permissions: contents: write` at job level following GitHub's recommended security practices

## 🛸 Mission Type (Type of Change)

- 🐛 Bug fix (fixes an issue)
- 🔧 Chore/maintenance (dependency updates, config changes, tooling)

## 🔬 Science Officer's Report (Testing)

**Test coverage:**
- [x] Tested manually (describe below)

**Manual testing details (if applicable):**
The fix cannot be fully tested until merged to master, as the workflow only runs on pushes to master with "Prepare release" commit messages. However:
- Verified the syntax matches GitHub Actions documentation
- Confirmed `permissions: contents: write` is the correct permission for pushing tags
- The change is minimal and follows established patterns from GitHub documentation

## 📡 Starfleet Command Reference (Related Issues)

Fixes workflow failure: https://github.com/jasonleibowitz/faker-galactic/actions/runs/19874377444/job/56957975646

## ✅ Pre-Launch Checklist (Required)

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `master`
- [x] All pre-commit hooks pass locally (ruff, mypy)
- [x] All tests pass locally (`pytest`) - N/A for workflow-only change
- [x] I have updated documentation (if needed) - Not needed for internal workflow fix
- [x] I have updated `.cspell.json` with new terms (if needed) - No new terms added
- [x] Type hints are included for all new functions - N/A for YAML file