### PR TITLE
Include uv.lock in release commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_no_return = true
 check_untyped_defs = true
+mypy_path = ["src"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -280,11 +280,11 @@ def create_release_branch(version: str) -> None:
 
 
 def commit_changes(version: str) -> None:
-    """Stage pyproject.toml and CHANGELOG.md, commit with message."""
+    """Stage pyproject.toml, CHANGELOG.md, and uv.lock, commit with message."""
     try:
         # Stage files
         subprocess.run(
-            ["git", "add", "pyproject.toml", "CHANGELOG.md"],
+            ["git", "add", "pyproject.toml", "CHANGELOG.md", "uv.lock"],
             check=True,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "faker-galactic"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "faker", version = "37.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## 🖖 Mission Briefing (Description)

**What does this PR do?**
Updates the release script to include `uv.lock` in release commits, and fixes mypy configuration to properly find our package.

**Why is this change needed?**
When `make release` runs, it updates `pyproject.toml` with the new version. The `uv run` command detects this change and automatically syncs `uv.lock` to match the new version. However, the release script was only staging `pyproject.toml` and `CHANGELOG.md`, leaving `uv.lock` modified but unstaged. This required manual intervention to commit the lock file after each release.

Additionally, mypy couldn't find the `faker_galactic` module when type-checking `scripts/release.py` because it didn't know to look in the `src` directory.

**Additional context:**
- **Root cause**: `uv` auto-syncs lock file when pyproject.toml changes, but release script didn't stage it
- **Why faker-galactic appears in uv.lock**: Normal behavior - dev dependencies install the package in editable mode for testing and development
- **Type checking fix**: Added `mypy_path = ["src"]` so mypy can find first-party packages without runtime path manipulation

## 🛸 Mission Type (Type of Change)

- 🐛 Bug fix (fixes an issue)
- 🔧 Chore/maintenance (dependency updates, config changes, tooling)

## 🔬 Science Officer's Report (Testing)

**Test coverage:**
- [x] Tested manually (describe below)

**Manual testing details (if applicable):**
- Verified mypy can now type-check `scripts/release.py`: `uv run mypy scripts/release.py` → Success
- Confirmed the release script stages all three files: `pyproject.toml`, `CHANGELOG.md`, and `uv.lock`
- The fix will be fully validated when the next release is created

## 📡 Starfleet Command Reference (Related Issues)

Resolves issue where `uv.lock` required manual commit after running `make release`

## ✅ Pre-Launch Checklist (Required)

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `master`
- [x] All pre-commit hooks pass locally (ruff, mypy)
- [x] All tests pass locally (`pytest`) - N/A for this change
- [x] I have updated documentation (if needed) - Not needed
- [x] I have updated `.cspell.json` with new terms (if needed) - No new terms added
- [x] Type hints are included for all new functions - No new functions added