### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-12-02
+
+- Include uv.lock in release commits [#5](https://github.com/jasonleibowitz/faker-galactic/pull/5)
+- Fix workflow permissions for pushing tags [#4](https://github.com/jasonleibowitz/faker-galactic/pull/4)
+- Prepare release v1.0.1 [#3](https://github.com/jasonleibowitz/faker-galactic/pull/3)
+- Update PyPi Links
+- Add Makefile and automated release workflow [#2](https://github.com/jasonleibowitz/faker-galactic/pull/2)
+- Add code quality checks with strict type safety [#1](https://github.com/jasonleibowitz/faker-galactic/pull/1)
+- Initial commit
+
 ## [1.0.1] - 2025-12-02
 
 - Update PyPi Links

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "faker-galactic"
-version = "1.0.1"
+version = "1.0.2"
 description = "Science fiction themed Faker provider for multiple universes including Star Trek, Star Wars, Battlestar Galactica, and more"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
# 📜 Captain's Log: Release 1.0.2

## 🎯 Mission Briefing

Prepare the ship for deployment to the PyPI Quadrant.

## ✅ Pre-Flight Checklist

- [x] **Warp core stable** - All tests passing
- [x] **Shields up** - Type checks passing
- [x] **Sensors calibrated** - Linting passing
- [x] **Captain's log updated** - CHANGELOG.md has entry for 1.0.2
- [x] **Stardate confirmed** - Version in pyproject.toml matches 1.0.2

## 🗺️ Navigation Coordinates

### 📋 Changes in this release:
- Include uv.lock in release commits [#5](https://github.com/jasonleibowitz/faker-galactic/pull/5)
- Fix workflow permissions for pushing tags [#4](https://github.com/jasonleibowitz/faker-galactic/pull/4)
- Prepare release v1.0.1 [#3](https://github.com/jasonleibowitz/faker-galactic/pull/3)
- Update PyPi Links
- Add Makefile and automated release workflow [#2](https://github.com/jasonleibowitz/faker-galactic/pull/2)
- Add code quality checks with strict type safety [#1](https://github.com/jasonleibowitz/faker-galactic/pull/1)
- Initial commit

View complete history in the [Captain's Log](../CHANGELOG.md#102---2025-12-02)

## 🚀 Post-Merge Protocol

Once this PR warps into master, the ship's computer will:

1. 🏷️ Create git tag `v1.0.2`
2. 📦 Build the package
3. 🚢 Transmit to PyPI at maximum warp
4. 📝 Generate GitHub Release notes

**Make it so.** 🖖
