### PR TITLE
Add Typing::Typed classifier and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
-  <img src="./logo.png" width="200"/>
+  <img src="https://raw.githubusercontent.com/jasonleibowitz/faker-galactic/master/logo.png" width="200"/>
 
   <h1>Faker Galactic</h1>
   <p>Custom Faker provider for generating science fiction themed data from popular sci-fi universes</p>
 
-[![package version](https://img.shields.io/pypi/v/faker-galactic)](https://test.pypi.org/project/faker-galactic/)
-[![mypy](https://img.shields.io/pypi/types/faker-galactic)]()
-[![python veresions](https://img.shields.io/pypi/pyversions/faker-galactic)]()
+[![package version](https://img.shields.io/pypi/v/faker-galactic)](https://pypi.org/project/faker-galactic/)
+![mypy](https://img.shields.io/pypi/types/faker-galactic)
+![python versions](https://img.shields.io/pypi/pyversions/faker-galactic)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jasonleibowitz/8f5ef0b2057559e749e4aa540c00e6f5/raw/faker-galactic-coverage.json)
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
+    "Typing :: Typed",
 ]
 dependencies = ["faker>=20.0.0"]
 


### PR DESCRIPTION
## 🖖 Mission Briefing (Description)

**What does this PR do?**
- Adds the `Typing :: Typed` classifier to `pyproject.toml` so PyPI recognizes the package as typed
- Fixes README badge links from test.pypi.org to pypi.org
- Fixes logo path to use GitHub raw URL for proper display on PyPI

**Why is this change needed?**
The PyPI Types badge (https://img.shields.io/pypi/types/faker-galactic) was showing the package as "untyped" because the `Typing :: Typed` classifier was missing from the package metadata. Even though we have `py.typed` marker file and strict mypy configuration, PyPI needs this classifier to advertise type support.

The README links were also pointing to test.pypi.org instead of the production pypi.org.

**Additional context:**
- The `py.typed` marker file already exists in `src/faker_galactic/`
- The package has strict mypy configuration with full type hints
- This change requires a new version release to take effect on PyPI

## 🛸 Mission Type (Type of Change)

- 📚 Documentation update
- 🔧 Chore/maintenance (dependency updates, config changes, tooling)

## 🔬 Science Officer's Report (Testing)

**Test coverage:**
- [x] All existing tests pass (`pytest`)
- [x] Tested manually (describe below)

**Manual testing details (if applicable):**
- Verified `py.typed` file is included in wheel distribution
- Confirmed classifier syntax matches PyPI requirements
- Checked that pre-commit hooks pass

## 📡 Starfleet Command Reference (Related Issues)

N/A - This is a metadata/documentation fix

## ✅ Pre-Launch Checklist (Required)

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is up to date with `master`
- [x] All pre-commit hooks pass locally (ruff, mypy)
- [x] All tests pass locally (`pytest`)
- [x] I have updated documentation (if needed)
- [x] I have updated `.cspell.json` with new terms (if needed)
- [x] Type hints are included for all new functions